### PR TITLE
feat(interviews): enable inline outcome updates and add awaiting action

### DIFF
--- a/components/Calendar.tsx
+++ b/components/Calendar.tsx
@@ -25,7 +25,7 @@ interface Interview {
   jobTitle?: string
   jobPostingLink?: string
   interviewer?: string
-  locationType?: "phone" | "link"
+  locationType?: "link" | "phone"
   interviewLink?: string
 }
 

--- a/components/InterviewForm.tsx
+++ b/components/InterviewForm.tsx
@@ -404,8 +404,8 @@ export default function InterviewForm({ initialValues, initialDate, interviewId,
                     <SelectValue/>
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="phone">Phone</SelectItem>
                     <SelectItem value="link">Link (online meeting)</SelectItem>
+                    <SelectItem value="phone">Phone</SelectItem>
                   </SelectContent>
                 </Select>
               </div>

--- a/lib/guestStorage.ts
+++ b/lib/guestStorage.ts
@@ -11,7 +11,7 @@ export type GuestInterview = {
   date?: string; // ISO (for Technical Test this represents the deadline)
   time?: string; // HH:mm:ss
   interviewer?: string;
-  locationType?: "phone" | "link";
+  locationType?: "link" | "phone";
   interviewLink?: string;
   notes?: string;
   createdAt: string; // ISO

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,17 +5,6 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export const STAGE_COLORS: Record<string, string> = {
-  Applied: "bg-gray-500",
-  "First Stage": "bg-blue-500",
-  "Initial Interview": "bg-indigo-500",
-  "Phone Screen": "bg-blue-500",
-  "Technical Interview": "bg-purple-500",
-  "Onsite Interview": "bg-orange-500",
-  "Final Round": "bg-pink-500",
-  Offer: "bg-green-500",
-}
-
 export function toISODate (d: Date) {
   const y = d.getFullYear()
   const m = String(d.getMonth() + 1).padStart(2, "0")


### PR DESCRIPTION
- remove unused STAGE_COLORS from lib/utils.ts to clean up
  code
 import Clock icon intoList for future use- change handleInterview to accept full Interview object so guest
  entries are handled locally and signed-in entries are updated via API;
  update guest state immutably removal
- optimistic update: set interview.outcome = "REJECTED" locally after a
  successful API call to reflect state immediately
- add handleAwaiting helper to set outcome to AWAITING_RESPONSE for both
  guest (local) and signed-in (API) interviews; refresh router after API
  update
- adjust action buttons:
  - guest rows call handleRejectInterview(interview) directly
  - signed-in rows conditionally show action buttons only when outcome
    is not rejected or passed
  - wrap Progress and Reject buttons with Tooltip triggers and content
    for improved UX (include tooltip text for progressing)
- various small fixes to callback usages and parameter handling to
  centralize outcome mutation and reduce duplicated logic

These changes unify how interview outcomes are updated (local vs API),
improve user feedback by applying optimistic updates, and add an
"awaiting response" action to reflect a common workflow state.