### PR TITLE
interview info

### DIFF
--- a/components/InterviewInfo.tsx
+++ b/components/InterviewInfo.tsx
@@ -2,15 +2,15 @@
 
 import {useQuery} from "@tanstack/react-query";
 import {useUser} from "@clerk/nextjs";
+import {listGuestInterviews} from "@/lib/guestStorage";
+import {useMemo} from "react";
 
 export default function InterviewInfo(props: {interviewId: string | null}) {
-  if (typeof props.interviewId === 'string' && props.interviewId.startsWith('guest_')) {
+  const {user} = useUser();
+  const isGuest = typeof props.interviewId === 'string' && props.interviewId.startsWith('guest_');
 
-  }
-  const user = useUser();
-
-  // Fetch interview data if interviewId is provided
-  const { data: interviewData } = useQuery({
+  // Fetch interview data from API for authenticated users
+  const { data: apiInterviewData } = useQuery({
     queryKey: ["interview", props.interviewId],
     queryFn: async () => {
       if (!props.interviewId) return null;
@@ -18,10 +18,190 @@ export default function InterviewInfo(props: {interviewId: string | null}) {
       if (!res.ok) throw new Error("Failed to fetch interview");
       return await res.json();
     },
-    enabled: !!props.interviewId && !!user,
+    enabled: !!props.interviewId && !!user && !isGuest,
   });
 
-  console.info("interviewData", interviewData);
+  // Get guest interview data from localStorage
+  const guestInterviewData = useMemo(() => {
+    if (!isGuest || !props.interviewId) return null;
+    const guestInterviews = listGuestInterviews();
+    return guestInterviews.find(i => i.id === props.interviewId);
+  }, [isGuest, props.interviewId]);
 
-  return <></>
+  const interviewData = isGuest ? guestInterviewData : apiInterviewData;
+
+  if (!interviewData) {
+    return <div className="text-center py-4 text-muted-foreground">Loading...</div>;
+  }
+
+  // For guest interviews
+  if (isGuest) {
+    return (
+      <div className="space-y-4">
+        <div>
+          <p className="text-sm font-medium text-muted-foreground">Company</p>
+          <p className="text-base">{interviewData.companyName}</p>
+        </div>
+
+        {interviewData.clientCompany && (
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">Client Company</p>
+            <p className="text-base">{interviewData.clientCompany}</p>
+          </div>
+        )}
+
+        <div>
+          <p className="text-sm font-medium text-muted-foreground">Job Title</p>
+          <p className="text-base">{interviewData.jobTitle}</p>
+        </div>
+
+        <div>
+          <p className="text-sm font-medium text-muted-foreground">Stage</p>
+          <p className="text-base">{interviewData.stage}</p>
+        </div>
+
+        {interviewData.date && (
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">
+              {interviewData.stage === "Technical Test" ? "Deadline" : "Interview Date"}
+            </p>
+            <p className="text-base">
+              {new Date(interviewData.date).toLocaleDateString("en-US", {
+                month: "long",
+                day: "numeric",
+                year: "numeric",
+                hour: interviewData.time ? "numeric" : undefined,
+                minute: interviewData.time ? "numeric" : undefined,
+              })}
+            </p>
+          </div>
+        )}
+
+        {interviewData.interviewer && (
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">Interviewer</p>
+            <p className="text-base">{interviewData.interviewer}</p>
+          </div>
+        )}
+
+        {interviewData.locationType && (
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">Interview Type</p>
+            <p className="text-base capitalize">{interviewData.locationType}</p>
+          </div>
+        )}
+
+        {interviewData.interviewLink && (
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">Interview Link</p>
+            <a href={interviewData.interviewLink} target="_blank" rel="noopener noreferrer" className="text-base text-blue-600 hover:underline">
+              {interviewData.interviewLink}
+            </a>
+          </div>
+        )}
+
+        {interviewData.jobPostingLink && (
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">Job Posting</p>
+            <a href={interviewData.jobPostingLink} target="_blank" rel="noopener noreferrer" className="text-base text-blue-600 hover:underline">
+              View Job Posting
+            </a>
+          </div>
+        )}
+
+        {interviewData.notes && (
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">Notes</p>
+            <p className="text-base whitespace-pre-wrap">{interviewData.notes}</p>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // For authenticated users - display API data
+  return (
+    <div className="space-y-4">
+      <div>
+        <p className="text-sm font-medium text-muted-foreground">Company</p>
+        <p className="text-base">{interviewData.company?.name}</p>
+      </div>
+
+      {interviewData.clientCompany && (
+        <div>
+          <p className="text-sm font-medium text-muted-foreground">Client Company</p>
+          <p className="text-base">{interviewData.clientCompany}</p>
+        </div>
+      )}
+
+      <div>
+        <p className="text-sm font-medium text-muted-foreground">Job Title</p>
+        <p className="text-base">{interviewData.jobTitle}</p>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium text-muted-foreground">Stage</p>
+        <p className="text-base">{interviewData.stage?.stage}</p>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium text-muted-foreground">Status</p>
+        <p className="text-base">{interviewData.status}</p>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium text-muted-foreground">Outcome</p>
+        <p className="text-base">{interviewData.outcome || "Pending"}</p>
+      </div>
+
+      {(interviewData.date || interviewData.deadline) && (
+        <div>
+          <p className="text-sm font-medium text-muted-foreground">
+            {interviewData.deadline ? "Deadline" : "Interview Date"}
+          </p>
+          <p className="text-base">
+            {new Date(interviewData.date || interviewData.deadline).toLocaleDateString("en-US", {
+              month: "long",
+              day: "numeric",
+              year: "numeric",
+              hour: "numeric",
+              minute: "numeric",
+            })}
+          </p>
+        </div>
+      )}
+
+      {interviewData.interviewer && (
+        <div>
+          <p className="text-sm font-medium text-muted-foreground">Interviewer</p>
+          <p className="text-base">{interviewData.interviewer}</p>
+        </div>
+      )}
+
+      {interviewData.stageMethod && (
+        <div>
+          <p className="text-sm font-medium text-muted-foreground">Interview Method</p>
+          <p className="text-base">{interviewData.stageMethod.method}</p>
+        </div>
+      )}
+
+      {interviewData.link && (
+        <div>
+          <p className="text-sm font-medium text-muted-foreground">Interview Link</p>
+          <a href={interviewData.link} target="_blank" rel="noopener noreferrer" className="text-base text-blue-600 hover:underline">
+            {interviewData.link}
+          </a>
+        </div>
+      )}
+
+      {interviewData.metadata?.jobListing && (
+        <div>
+          <p className="text-sm font-medium text-muted-foreground">Job Posting</p>
+          <a href={interviewData.metadata.jobListing as string} target="_blank" rel="noopener noreferrer" className="text-base text-blue-600 hover:underline">
+            View Job Posting
+          </a>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/components/InterviewsList.tsx
+++ b/components/InterviewsList.tsx
@@ -11,7 +11,7 @@ import {useUser} from "@clerk/nextjs";
 import {SiGooglemeet, SiZoom} from "react-icons/si";
 import {PiMicrosoftTeamsLogoFill} from "react-icons/pi";
 import {Tooltip, TooltipContent, TooltipTrigger} from "@/components/ui/tooltip";
-import {Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle} from "@/components/ui/dialog";
+import {Dialog, DialogContent, DialogHeader, DialogTitle} from "@/components/ui/dialog";
 import InterviewForm from "@/components/InterviewForm";
 import {useRouter} from "next/navigation";
 import {listGuestInterviews, removeGuestInterview} from "@/lib/guestStorage";
@@ -346,8 +346,8 @@ export default function InterviewsList() {
               .map((interview) => (
                 <div
                   key={interview.id}
-                  className="flex items-start justify-between p-4 rounded-lg border border-border hover:bg-accent transition-colors"
-                  onClick={(e) => {
+                  className="flex items-start justify-between p-4 rounded-lg border border-border hover:bg-accent transition-colors cursor-pointer"
+                  onClick={() => {
                     setSelectedInterview(interview)
                     setInfoDialogOpen(true)
                   }}


### PR DESCRIPTION
### Summary

- Add clickable interview cards to open an info dialog showing interview details.
- Mount InterviewInfo in the dialog and render a DialogHeader with the interview title.
- Fetch interview data for authenticated users from /api/interview/:id using react-query and Clerk's useUser.
- Support guest interviews by loading from localStorage (listGuestInterviews) and rendering a read-only view for guest entries.
- Improve InterviewsList UX: clearer keyboard/click affordance (cursor-pointer) and simplified onClick to open the dialog.
- Only run API queries for authenticated, non-guest interviews; show loading placeholder while resolving.