### PR TITLE
feat: add outcome filter and interview stats panel

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,15 @@
 import Calendar from "@/components/Calendar";
 import InterviewsList from "@/components/InterviewsList";
+import Stats from "@/components/Stats";
 
 export default function Home() {
   return (
     <div className="flex gap-6 flex-col lg:flex-row">
       <InterviewsList />
-      <Calendar />
+      <div className="flex flex-col gap-6">
+        <Calendar />
+        <Stats />
+      </div>
     </div>
   );
 }

--- a/components/InterviewsList.tsx
+++ b/components/InterviewsList.tsx
@@ -103,6 +103,8 @@ export default function InterviewsList() {
   const setCompanyFilter = useAppStore((s) => s.setFilteredCompany)
   const dateFilter = useMemo(() => (filteredDateISO ? new Date(filteredDateISO + "T00:00:00") : null), [filteredDateISO]);
   const companyFilter = useAppStore((s) => s.filteredCompany);
+  const outcomeFilter = useAppStore((s) => s.filteredOutcome);
+  const setOutcomeFilter = useAppStore((s) => s.setFilteredOutcome);
   const [futureOnly, setFutureOnly] = useState(false);
   const [progressDialogOpen, setProgressDialogOpen] = useState(false);
   const [infoDialogOpen, setInfoDialogOpen] = useState(false);
@@ -249,7 +251,8 @@ export default function InterviewsList() {
   const displayedInterviews = baseList.filter((interview) => {
     const matchDate = dateFilter ? isSameDay(interview.date, dateFilter) : true;
     const matchCompany = companyFilter ? interview.company.name === companyFilter : true;
-    return matchDate && matchCompany;
+    const matchOutcome = outcomeFilter ? interview.outcome === outcomeFilter : true;
+    return matchDate && matchCompany && matchOutcome;
   });
 
   const days = [];
@@ -300,7 +303,9 @@ export default function InterviewsList() {
         <div className="flex items-center justify-between mb-6">
           <div>
             <h2 className="text-2xl font-semibold">
-              {companyFilter && dateFilter
+              {outcomeFilter
+                ? `${formatOutcome(outcomeFilter)} Interviews`
+                : companyFilter && dateFilter
                 ? `${companyFilter} Interviews for ${dateFilter.toLocaleDateString("en-US", {
                     month: "long",
                     day: "numeric",
@@ -340,6 +345,12 @@ export default function InterviewsList() {
                   </Button>
                 )}
               </>
+            )}
+            {outcomeFilter && (
+              <Button variant="ghost" onClick={() => setOutcomeFilter(null)} className="mt-2 h-8 cursor-pointer">
+                <X className="h-3 w-3 mr-1" />
+                Clear Outcome filter
+              </Button>
             )}
           </div>
         </div>

--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useUser } from "@clerk/nextjs";
+import { Card } from "@/components/ui/card";
+import { useAppStore } from "@/lib/store";
+import { cn } from "@/lib/utils";
+
+async function getInterviews() {
+  const url = new URL('/api/interviews', window.location.origin);
+  url.searchParams.set('includePast', 'true');
+
+  const res = await fetch(url.toString(), {
+    method: "GET",
+  });
+
+  if (!res.ok) {
+    throw new Error("failed to get interviews");
+  }
+
+  return await res.json();
+}
+
+interface OutcomeStat {
+  outcome: string;
+  count: number;
+  label: string;
+  color: string;
+}
+
+const outcomeConfig: Record<string, { label: string; color: string }> = {
+  SCHEDULED: { label: "Scheduled", color: "bg-blue-500" },
+  AWAITING_RESPONSE: { label: "Awaiting Response", color: "bg-yellow-500" },
+  PASSED: { label: "Passed", color: "bg-green-500" },
+  REJECTED: { label: "Rejected", color: "bg-red-500" },
+  OFFER_RECEIVED: { label: "Offer Received", color: "bg-purple-500" },
+  OFFER_ACCEPTED: { label: "Offer Accepted", color: "bg-emerald-500" },
+  OFFER_DECLINED: { label: "Offer Declined", color: "bg-gray-500" },
+  WITHDREW: { label: "Withdrew", color: "bg-orange-500" },
+};
+
+export default function Stats() {
+  const { user } = useUser();
+  const filteredOutcome = useAppStore((s) => s.filteredOutcome);
+  const setFilteredOutcome = useAppStore((s) => s.setFilteredOutcome);
+  const setFilteredDate = useAppStore((s) => s.setFilteredDate);
+  const setFilteredCompany = useAppStore((s) => s.setFilteredCompany);
+
+  const { data: interviews } = useQuery({
+    queryKey: ["interviews", user?.id],
+    queryFn: getInterviews,
+    enabled: !!user?.id,
+  });
+
+  if (!user || !interviews) {
+    return null;
+  }
+
+  // Group interviews by outcome
+  const outcomeCounts: Record<string, number> = {};
+  interviews.forEach((interview: { outcome?: string }) => {
+    const outcome = interview.outcome || "SCHEDULED";
+    outcomeCounts[outcome] = (outcomeCounts[outcome] || 0) + 1;
+  });
+
+  // Convert to array of stats
+  const stats: OutcomeStat[] = Object.entries(outcomeCounts)
+    .map(([outcome, count]) => ({
+      outcome,
+      count,
+      label: outcomeConfig[outcome]?.label || outcome,
+      color: outcomeConfig[outcome]?.color || "bg-gray-500",
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  const handleStatClick = (outcome: string) => {
+    // If already filtered by this outcome, clear the filter
+    if (filteredOutcome === outcome) {
+      setFilteredOutcome(null);
+    } else {
+      // Clear other filters and set outcome filter
+      setFilteredDate(null);
+      setFilteredCompany(null);
+      setFilteredOutcome(outcome);
+    }
+  };
+
+  return (
+    <Card className="p-6">
+      <h2 className="text-xl font-semibold mb-4">Interview Stats</h2>
+      <div className="grid grid-cols-2 md:grid-cols-1 gap-4">
+        {stats.map((stat) => (
+          <button
+            key={stat.outcome}
+            onClick={() => handleStatClick(stat.outcome)}
+            className={cn(
+              "flex flex-col items-center p-2 rounded-lg border transition-all hover:scale-105 cursor-pointer",
+              filteredOutcome === stat.outcome
+                ? "border-primary bg-accent"
+                : "border-border hover:bg-accent"
+            )}
+          >
+            <div className={cn("w-8 h-8 rounded-full flex items-center justify-center mb-2", stat.color)}>
+              <span className="text-2xl font-bold text-white">{stat.count}</span>
+            </div>
+            <span className="text-sm text-center font-medium">{stat.label}</span>
+          </button>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -7,11 +7,13 @@ export type ISODate = string; // e.g. "2025-11-06"
 export type AppState = {
   filteredDate: ISODate | null;
   filteredCompany: string | null;
+  filteredOutcome: string | null;
 };
 
 export type AppActions = {
   setFilteredDate: (day: ISODate | null) => void;
   setFilteredCompany: (name: string | null) => void;
+  setFilteredOutcome: (outcome: string | null) => void;
 };
 
 export const useAppStore = create<AppState & AppActions>((set) => ({
@@ -22,4 +24,8 @@ export const useAppStore = create<AppState & AppActions>((set) => ({
   // Company
   filteredCompany: null,
   setFilteredCompany: (name) => set({ filteredCompany: name }),
+
+  // Outcome
+  filteredOutcome: null,
+  setFilteredOutcome: (outcome) => set({ filteredOutcome: outcome }),
 }));


### PR DESCRIPTION
- Add outcome state to global store (filteredOutcome, setFilteredOutcome)
  to support filtering interviews by outcome.
- Wire outcome filter into InterviewsList:
  - Read and apply outcome filter when computing displayedInterviews.
  - Update header/title to show outcome label when active.
  - Add a "Clear Outcome filter" button to remove the filter.
- Introduce a new Stats component and include it on the home page
  alongside Calendar. Stats fetches interviews and exposes outcome
  statistics (outcome mapping and colors) and hooks into the app store
  to set/clear filters.
- Minor layout change: wrap Calendar and Stats in a vertical column on
  larger layout.

These changes enable viewing interviews by outcome and provide a
stats panel to drive outcome-based exploration.