### PR TITLE
feat(ui): add meeting buttons and feature-flag stats

### DIFF
--- a/components/InterviewInfo.tsx
+++ b/components/InterviewInfo.tsx
@@ -4,6 +4,9 @@ import {useQuery} from "@tanstack/react-query";
 import {useUser} from "@clerk/nextjs";
 import {listGuestInterviews} from "@/lib/guestStorage";
 import {useMemo} from "react";
+import {SiGooglemeet, SiZoom} from "react-icons/si";
+import {Button} from "@/components/ui/button";
+import {PiMicrosoftTeamsLogoFill} from "react-icons/pi";
 
 export default function InterviewInfo(props: {interviewId: string | null}) {
   const {user} = useUser();
@@ -119,6 +122,32 @@ export default function InterviewInfo(props: {interviewId: string | null}) {
     );
   }
 
+  const getStageMethodButton = (stageMethod: string, link: string) => {
+    switch (stageMethod) {
+      case "Zoom": {
+        return (
+          <Button variant={"outline"} className={"cursor-pointer"} onClick={() => window.open(link)}>
+            <SiZoom/>
+          </Button>
+        )
+      }
+      case "Teams": {
+        return (
+          <Button variant={"outline"} className={"cursor-pointer"} onClick={() => window.open(link)}>
+            <PiMicrosoftTeamsLogoFill />
+          </Button>
+        )
+      }
+      case "Google Meet": {
+        return (
+          <Button variant={"outline"} className={"cursor-pointer"} onClick={() => window.open(link)}>
+            <SiGooglemeet />
+          </Button>
+        )
+      }
+    }
+  }
+
   // For authenticated users - display API data
   return (
     <div className="space-y-4">
@@ -188,9 +217,7 @@ export default function InterviewInfo(props: {interviewId: string | null}) {
       {interviewData.link && (
         <div>
           <p className="text-sm font-medium text-muted-foreground">Interview Link</p>
-          <a href={interviewData.link} target="_blank" rel="noopener noreferrer" className="text-base text-blue-600 hover:underline">
-            {interviewData.link}
-          </a>
+          {getStageMethodButton(interviewData.stageMethod.method, interviewData.link)}
         </div>
       )}
 

--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -5,6 +5,7 @@ import { useUser } from "@clerk/nextjs";
 import { Card } from "@/components/ui/card";
 import { useAppStore } from "@/lib/store";
 import { cn } from "@/lib/utils";
+import {useFlags} from "@flags-gg/react-library";
 
 async function getInterviews() {
   const url = new URL('/api/interviews', window.location.origin);
@@ -45,6 +46,7 @@ export default function Stats() {
   const setFilteredOutcome = useAppStore((s) => s.setFilteredOutcome);
   const setFilteredDate = useAppStore((s) => s.setFilteredDate);
   const setFilteredCompany = useAppStore((s) => s.setFilteredCompany);
+  const {is} = useFlags()
 
   const { data: interviews } = useQuery({
     queryKey: ["interviews", user?.id],
@@ -84,6 +86,10 @@ export default function Stats() {
       setFilteredOutcome(outcome);
     }
   };
+
+  if (is("stats").disabled()) {
+    return <></>
+  }
 
   return (
     <Card className="p-6">


### PR DESCRIPTION
- Add provider-specific meeting buttons to InterviewInfo (Zoom, Teams, Google Meet) using react-icons and the existing Button component.
- Replace plain anchor link with a getStageMethodButton helper that renders an outlined button with the correct icon and opens meeting links in a new window.
- Integrate feature flagging into Stats component with flags-gg hook and early-return when the "stats" flag is disabled to hide the stats card.
- Tidy imports and move the flag check closer to component setup.