### PR TITLE
feat(form): add optional deadline and conditional date/time UI

### DIFF
--- a/lib/validations/interview.ts
+++ b/lib/validations/interview.ts
@@ -28,8 +28,9 @@ export type InterviewFormData = z.infer<typeof interviewFormSchema>;
 // Validation schema for editing interviews
 export const editInterviewSchema = z.object({
   clientCompany: z.string().optional(),
-  date: z.string().min(1, "Date is required"),
-  time: z.string().min(1, "Time is required"),
+  date: z.string().optional(),
+  time: z.string().optional(),
+  deadline: z.string().optional(),
   link: z.string().url("Must be a valid URL").optional().or(z.literal("")),
   interviewer: z.string().optional(),
   notes: z.string().optional(),
@@ -38,6 +39,17 @@ export const editInterviewSchema = z.object({
     .url("Must be a valid URL")
     .optional()
     .or(z.literal("")),
-});
+}).refine(
+  (data) => {
+    // Either deadline OR (date AND time) must be provided
+    const hasDeadline = !!data.deadline;
+    const hasDateTime = !!data.date && !!data.time;
+    return hasDeadline || hasDateTime;
+  },
+  {
+    message: "Either deadline or date/time is required",
+    path: ["date"],
+  }
+);
 
 export type EditInterviewData = z.infer<typeof editInterviewSchema>;


### PR DESCRIPTION
Add support for an optional deadline on interviews and make the
form handle either a single datetime deadline or separate date/time
inputs. Track hasDeadline, parse/format a deadline for form reset,
include deadline in submit payload, and await query invalidations
after save. Replace required date/time validations with optional
fields so interviews can use only a deadline. Update the UI to show
a datetime-local deadline input when an interview has a deadline,
otherwise show the existing date and time inputs. Fix input ids,
error handling, and ensure ISO strings are sent or nullified.