### PR TITLE
feat(interview): add stage selection and API endpoint

### DIFF
--- a/app/api/stage-methods/route.ts
+++ b/app/api/stage-methods/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+
+export async function GET() {
+  try {
+    const stageMethods = await prisma.stageMethod.findMany({
+      orderBy: { method: "asc" },
+    });
+
+    return NextResponse.json(stageMethods);
+  } catch (error) {
+    console.error("GET /api/stage-methods error", error);
+    return NextResponse.json(
+      { error: "Failed to fetch stage methods" },
+      { status: 500 }
+    );
+  }
+}

--- a/components/Calendar.tsx
+++ b/components/Calendar.tsx
@@ -200,7 +200,7 @@ export default function Calendar() {
             <div className="flex gap-1">
               {is("calendar sync").enabled() && (
                 <Dialog>
-                  <DialogTrigger><CalendarHeart /></DialogTrigger>
+                  <DialogTrigger><CalendarHeart className="h-4 w-4 cursor-pointer" /></DialogTrigger>
                   <DialogContent>
                     <DialogHeader>
                       <DialogTitle>Calendar Sync</DialogTitle>

--- a/components/CalendarSync.tsx
+++ b/components/CalendarSync.tsx
@@ -6,7 +6,6 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {useFlags} from "@flags-gg/react-library";
-import {Card} from "@/components/ui/card";
 
 interface CalendarSettings {
   calendarUuid: string;

--- a/lib/validations/interview.ts
+++ b/lib/validations/interview.ts
@@ -39,6 +39,7 @@ export const editInterviewSchema = z.object({
     .url("Must be a valid URL")
     .optional()
     .or(z.literal("")),
+  stageMethodId: z.number().optional(),
 }).refine(
   (data) => {
     // Either deadline OR (date AND time) must be provided


### PR DESCRIPTION
Add stageMethodId to interview validation schema and propagate it
through the edit form so users can view and set the interview method.
Create a new GET /api/stage-methods route that returns ordered stage
methods from the database for populating the select. Update the
InterviewEditForm to fetch stage methods, include a controlled Select
component (with react-hook-form Controller) and map selected value to
stageMethodId when initializing and submitting the form.

Also make small UI tweaks: add explicit sizing/cursor to the calendar
dialog trigger icon and remove an unused Card import from CalendarSync.