### PR TITLE
fix(ui): close company dropdown after selecting suggestion

### DIFF
--- a/components/InterviewForm.tsx
+++ b/components/InterviewForm.tsx
@@ -347,9 +347,9 @@ export default function InterviewForm({ initialValues, initialDate, interviewId,
                 <CommandInput placeholder={"Search Company"} onValueChange={(e) => setSearchCompanyValue(e)} />
                 <CommandEmpty>
                   <Button onClick={() => {
-                    setCompanyName(searchCompanyValue)}
-                    setCompanyOpen(false);
-                  }>{searchCompanyValue}</Button>
+                    setCompanyName(searchCompanyValue)
+                    setCompanyOpen(false)
+                  }}>{searchCompanyValue}</Button>
                 </CommandEmpty>
                 <CommandGroup>
                   {companies?.map((c) => (


### PR DESCRIPTION
When a user selects a company suggestion from the CommandEmpty button,
the company dropdown remains open. This change closes the dropdown
by setting companyOpen to false immediately after setting the
company name. It improves UX by preventing the dropdown from staying
open after selection.