### PR TITLE
chore: remove console log from InterviewInfo component

### DIFF
--- a/components/InterviewInfo.tsx
+++ b/components/InterviewInfo.tsx
@@ -32,7 +32,6 @@ export default function InterviewInfo(props: {interviewId: string | null}) {
   }, [isGuest, props.interviewId]);
 
   const interviewData = isGuest ? guestInterviewData : apiInterviewData;
-  console.info("Interview info", interviewData);
 
   // Normalize guest/API data into a single view model for a unified layout
   interface GuestInterview {


### PR DESCRIPTION
Remove a leftover console.info call from components/InterviewInfo.tsx
that logged interviewData. The debug output is unnecessary in
production and can clutter logs and reveal internal state. Cleaning
this up keeps the codebase tidy and avoids accidental exposure of
data in server or client consoles.